### PR TITLE
docs: 登记 dsh-chat-import

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ npx @deepseek-ai/dsh web
 - [Anionex/dsh-turn-rewind](https://github.com/Anionex/dsh-turn-rewind) ⭐ 32 - 对话与代码状态回退，基于持久化 Change Ledger。
 - [csyangwen/dsh-memory-evolve](https://github.com/csyangwen/dsh-memory-evolve) ⭐ 30 - 纯插件实现跨会话长期记忆 + 后台自我进化：五轨记忆、技能自我进化、待办与调度，零核心修改。
 - [titanwings/dsh-automation](https://github.com/titanwings/dsh-automation) ⭐ 23 - 自动化插件：让任务按计划在全新 Agent Session 中运行，支持定时任务管理。
+- [Nwflower/dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) ⭐ 21 - 13 源全保真导入（Claude Code/Codex/ChatGPT/Cursor/Gemini/Reasonix/opencode/ZCode/Grok Build/OpenClaw/Pi/Hermes/Kimi）历史会话为可续聊 DSH 会话，支持反向导出/同步回 Claude Code。
 
 ## 集成与周边工具
 


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-chat-import |
| 仓库 | https://github.com/Nwflower/dsh-chat-import |
| 一句话说明 | 13 种编码 Agent 聊天记录全保真导入为可续聊 DSH 会话，并支持反向导出/同步回 Claude Code |
| 版本 | 0.3.1（npm `dsh-chat-import`） |

## 自检清单

- [x] 仓库已打 `dsh-plugin` topic
- [x] npm 已发布（0.1.0–0.3.1），340 测试 + CI 全绿
- [x] 13 个 `import_*` 工具 + `scan_discover` / `export_claude` / `sync_to_claude` / `list_imported_sessions` / `retract_import` 实测通过

## 改动内容

在 `## 功能扩展插件` 分类末尾（`titanwings/dsh-automation` 之后）追加：

`- [Nwflower/dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) ⭐ 21 - 13 源全保真导入（Claude Code/Codex/ChatGPT/Cursor/Gemini/Reasonix/opencode/ZCode/Grok Build/OpenClaw/Pi/Hermes/Kimi）历史会话为可续聊 DSH 会话，支持反向导出/同步回 Claude Code。`