### PR TITLE
Add dsh-reverse-skill (85-skill reverse-engineering pack) to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ npx @deepseek-ai/dsh web
 - [Discord 社区](https://discord.gg/Ycq5dCaS4) - 官方 Discord。
 
 ## 插件市场与插件发现
+- [dhicoc/dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) — 完整 reverse-skill（85 个 SKILL.md）的 DeepSeek Harness 插件：逆向工程、授权渗透测试与安全研究的技能路由包。
+- [dhicoc/dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) - Complete reverse-skill pack (85 SKILL.md) as a DeepSeek Harness Cordis plugin: reverse engineering, authorized pentesting and security-research skill router.
 
 - [AdamPlatin123/awesome-dsh-plugins](https://github.com/AdamPlatin123/awesome-dsh-plugins) ⭐ 625 - 插件雷达：自动扫描发现全网 dsh 插件候选，测试合格后移入精选目录。
 - [awesome-dsh-plugin/awesome-dsh-plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) ⭐ 487 - DSH 插件精选列表（中英双语）。

--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ npx @deepseek-ai/dsh web
 
 ## 插件市场与插件发现
 - [dhicoc/dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) — 完整 reverse-skill（85 个 SKILL.md）的 DeepSeek Harness 插件：逆向工程、授权渗透测试与安全研究的技能路由包。
-- [dhicoc/dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) - Complete reverse-skill pack (85 SKILL.md) as a DeepSeek Harness Cordis plugin: reverse engineering, authorized pentesting and security-research skill router.
-
 - [AdamPlatin123/awesome-dsh-plugins](https://github.com/AdamPlatin123/awesome-dsh-plugins) ⭐ 625 - 插件雷达：自动扫描发现全网 dsh 插件候选，测试合格后移入精选目录。
 - [awesome-dsh-plugin/awesome-dsh-plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) ⭐ 487 - DSH 插件精选列表（中英双语）。
 - [bruc3van/awesome-dsh-plugin](https://github.com/bruc3van/awesome-dsh-plugin) ⭐ 54 - "30 秒找到适合你的插件"：按解决什么问题、适合谁来导航，而不只是仓库罗列。

--- a/README_EN.md
+++ b/README_EN.md
@@ -36,7 +36,7 @@ npx @deepseek-ai/dsh web
 - [Discord community](https://discord.gg/Ycq5dCaS4) - Official Discord.
 
 ## Plugin Marketplaces & Discovery
-
+- [dhicoc/dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) - Complete reverse-skill pack (85 SKILL.md) as a DeepSeek Harness Cordis plugin: reverse engineering, authorized pentesting and security-research skill router.
 - [AdamPlatin123/awesome-dsh-plugins](https://github.com/AdamPlatin123/awesome-dsh-plugins) ⭐ 625 - Plugin radar: automatically scans and discovers dsh plugin candidates; tested ones graduate into a curated directory.
 - [awesome-dsh-plugin/awesome-dsh-plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) ⭐ 487 - A curated list of DSH plugins (English & Chinese).
 - [bruc3van/awesome-dsh-plugin](https://github.com/bruc3van/awesome-dsh-plugin) ⭐ 54 - "Find the right plugin in 30 seconds": navigates by what problem a plugin solves and who it's for, not just a repo dump.


### PR DESCRIPTION
Adds [dhicoc/dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) — a DeepSeek Harness Cordis plugin bundling 85 SKILL.md reverse-engineering / authorized-pentest / security-research skills.

Installable via `dsh plugin add github:dhicoc/dsh-reverse-skill`.