### PR TITLE
add: dsh-mcp-manager (MCP visual manager plugin) to Web UI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ npx @deepseek-ai/dsh web
 - [vlln/whale-girl](https://github.com/vlln/whale-girl) ⭐ 145 - QQ 宠物形态的桌面宠物插件：右下角悬浮，可拖拽、投喂、玩耍。
 - [Nagi-ovo/dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) ⭐ 86 - 在 DSH 对话中生成交互式可视化：模型把交互式 HTML 卡片直接画进会话流。
 - [omdsh-dev/dsh-genui](https://github.com/omdsh-dev/dsh-genui) ⭐ 82 - GenUI：回复内直接渲染布局、图表、表单、测验等交互组件。
+- [Js2Hou/dsh-mcp-manager](https://github.com/Js2Hou/dsh-mcp-manager) - MCP 可视化管理插件：设置 → MCP 页查看/新增/删除/启停 MCP 服务器，实时显示连接状态与工具数。
 
 ## 功能扩展插件
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -74,6 +74,7 @@ npx @deepseek-ai/dsh web
 - [vlln/whale-girl](https://github.com/vlln/whale-girl) ⭐ 145 - QQ-pet-style desktop pet plugin: floats in the corner, draggable, feedable, playable.
 - [Nagi-ovo/dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) ⭐ 86 - Generative visualization in conversation: the model renders interactive HTML cards directly into the chat stream.
 - [omdsh-dev/dsh-genui](https://github.com/omdsh-dev/dsh-genui) ⭐ 82 - GenUI: interactive components — layouts, charts, forms, quizzes — rendered inline in assistant replies.
+- [Js2Hou/dsh-mcp-manager](https://github.com/Js2Hou/dsh-mcp-manager) - Visual MCP manager: inspect, add, remove, enable/disable MCP servers from Settings → MCP, with live connection status and tool counts.
 
 ## Capability Plugins
 


### PR DESCRIPTION
补充 dsh-mcp-manager：DeepSeek Harness 的 MCP 可视化管理插件，加入「Web UI 增强与皮肤」分类。

- 设置 → MCP 页可视化查看/新增/删除/启停 MCP 服务器（@deepseek-ai/dsh-mcp-client 实例）
- 实时显示每台服务器的连接状态与已注册工具数，支持独立连接测试
- 修改写入 cordis.patch.yml，HMR 热应用、重启不丢；界面中英双语自动切换
- npm 包 @js2hou/dsh-mcp-manager，一键安装：npx -y --package @deepseek-ai/dsh dsh plugin --profile web add @js2hou/dsh-mcp-manager