### PR TITLE
Add dsh-passwords plugin (login gateway)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ npx @deepseek-ai/dsh web
 - [csyangwen/dsh-memory-evolve](https://github.com/csyangwen/dsh-memory-evolve) ⭐ 64 - 纯插件实现跨会话长期记忆 + 后台自我进化：五轨记忆、技能自我进化、待办与调度，零核心修改。
 - [icetomoyo/dsh_workflow](https://github.com/icetomoyo/dsh_workflow) ⭐ 55 - 把 UltraCode 式多 Agent 调度升级为可生成、可保存、可治理、可恢复的 Workflow 层。
 - [Anionex/dsh-turn-rewind](https://github.com/Anionex/dsh-turn-rewind) ⭐ 47 - 对话与代码状态回退，基于持久化 Change Ledger。
+- [slywalker2006/dsh-passwords](https://github.com/slywalker2006/dsh-passwords) ⭐ 3 - dsh 登录网关（密码门）：首次配置 + 多用户账号，bcrypt 加密、防爆破锁定、审计日志、自动 HTTPS，远程访问 dsh 不再裸奔。
 
 ## Agent Skills
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -87,6 +87,7 @@ npx @deepseek-ai/dsh web
 - [csyangwen/dsh-memory-evolve](https://github.com/csyangwen/dsh-memory-evolve) ⭐ 64 - Plugin-only cross-session long-term memory and background self-evolution: five-track memory, skill self-evolution, todos, and scheduling — zero core modifications.
 - [icetomoyo/dsh_workflow](https://github.com/icetomoyo/dsh_workflow) ⭐ 55 - Upgrades one-shot multi-agent dispatch into a workflow layer that is generatable, savable, governable, and resumable.
 - [Anionex/dsh-turn-rewind](https://github.com/Anionex/dsh-turn-rewind) ⭐ 47 - Rewind conversation and workspace state, powered by a persistent Change Ledger.
+- [slywalker2006/dsh-passwords](https://github.com/slywalker2006/dsh-passwords) ⭐ 3 - Login gateway (password door) for the DSH web UI: first-run setup, multi-user accounts, bcrypt encryption, brute-force lockout, audit log, and automatic HTTPS.
 
 ## Agent Skills
 


### PR DESCRIPTION
Add [slywalker2006/dsh-passwords](https://github.com/slywalker2006/dsh-passwords) — a login gateway (password door) for the DeepSeek Harness web UI.

- First-run setup flow (create the primary account on first visit)
- Multi-user accounts managed from the dsh settings page
- bcrypt password hashing + AES-256-GCM at-rest encryption
- Brute-force lockout (5 failures -> 15 min) and audit log
- Automatic HTTPS via Let's Encrypt with 80-to-443 redirect
- Install: `npm install -g dsh-passwords` (or `git clone` + `npm install && npm run build`)
- License: BSD-3-Clause

The upstream README (EN + zh-CN) and settings-page plugin card are the main entry points.