### PR TITLE
Add `dsh-context` to Web UI Enhancements & Skins

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ npx @deepseek-ai/dsh web
 - [vlln/whale-girl](https://github.com/vlln/whale-girl) ⭐ 145 - QQ 宠物形态的桌面宠物插件：右下角悬浮，可拖拽、投喂、玩耍。
 - [Nagi-ovo/dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) ⭐ 86 - 在 DSH 对话中生成交互式可视化：模型把交互式 HTML 卡片直接画进会话流。
 - [omdsh-dev/dsh-genui](https://github.com/omdsh-dev/dsh-genui) ⭐ 82 - GenUI：回复内直接渲染布局、图表、表单、测验等交互组件。
+- [bowenliang123/dsh-context](https://github.com/bowenliang123/dsh-context) ⭐ 42 - 上下文洞察面板：一眼看清模型上下文窗口的组成与变化——构成对照窗口大小、按请求历史趋势、压缩/注入事件、消息级 token 统计。
 
 ## 功能扩展插件
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -74,6 +74,7 @@ npx @deepseek-ai/dsh web
 - [vlln/whale-girl](https://github.com/vlln/whale-girl) ⭐ 145 - QQ-pet-style desktop pet plugin: floats in the corner, draggable, feedable, playable.
 - [Nagi-ovo/dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) ⭐ 86 - Generative visualization in conversation: the model renders interactive HTML cards directly into the chat stream.
 - [omdsh-dev/dsh-genui](https://github.com/omdsh-dev/dsh-genui) ⭐ 82 - GenUI: interactive components — layouts, charts, forms, quizzes — rendered inline in assistant replies.
+- [bowenliang123/dsh-context](https://github.com/bowenliang123/dsh-context) ⭐ 42 - Context insight panel: see what the model's context window is made of and how it evolves — composition vs. window size, per-request history, compression/injection events, and per-message token stats.
 
 ## Capability Plugins
 


### PR DESCRIPTION
Adds [dsh-context](https://github.com/bowenliang123/dsh-context) under Web UI Enhancements & Skins.

**Context insight panel** for DeepSeek Harness: adds a Context tab beside Chat/Trajectory, to understand what the model's context window is made of and how it evolves — composition, history, events, and per-message stats.

Install:

```sh
dsh plugin --profile web add dsh-context
```

- dsh.bundle manifest (installable via `dsh plugin add`) + dsh.client manifest for the web UI half
- `dsh-plugin` topic already set; Apache-2.0 licensed
