### PR TITLE
Add SandbaseAI native DSH plugin store

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ npx @deepseek-ai/dsh web
 - [hikariming/dshfind](https://github.com/hikariming/dshfind) ⭐ 176 - DSH 原理学习、插件市场与最佳实践。
 - [Nagi-ovo/dsh-find-plugins](https://github.com/Nagi-ovo/dsh-find-plugins) ⭐ 151 - 帮 DSH 搜索、安装并验证 GitHub 插件的 Skill。
 - [OBdangshang07/DSH_Creative_Workshop](https://github.com/OBdangshang07/DSH_Creative_Workshop) ⭐ 60 - Steam 创意工坊式的插件发现、信任评估、图搜索、合集与事务化安装规划。
+- [sandbaseai/dsh-plugin-store](https://github.com/sandbaseai/dsh-plugin-store) ⭐ 1 - 原生集成到 DSH Settings 的社区插件商店：浏览、搜索、标签筛选并管理 4,100+ 条目；安装前校验 Leaderboard 状态与包规范，提供可复现的 Preview 安装包。
 
 ## 桌面客户端
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -48,6 +48,7 @@ npx @deepseek-ai/dsh web
 - [hikariming/dshfind](https://github.com/hikariming/dshfind) ⭐ 176 - Learn DSH principles, plugin marketplace, and best practices.
 - [Nagi-ovo/dsh-find-plugins](https://github.com/Nagi-ovo/dsh-find-plugins) ⭐ 151 - A DSH skill that finds, installs, and verifies GitHub plugins.
 - [OBdangshang07/DSH_Creative_Workshop](https://github.com/OBdangshang07/DSH_Creative_Workshop) ⭐ 60 - Steam-Workshop-inspired discovery, trust scoring, graph search, collections, and transactional install planning.
+- [sandbaseai/dsh-plugin-store](https://github.com/sandbaseai/dsh-plugin-store) ⭐ 1 - A community plugin store embedded in DSH Settings for browsing, searching, filtering, and managing 4,100+ entries; it validates Leaderboard status and package specs before install and ships a reproducible preview package.
 
 ## Desktop Clients
 


### PR DESCRIPTION
## Summary

- add `sandbaseai/dsh-plugin-store` to Plugin Marketplaces & Discovery
- keep the Chinese and English READMEs in sync
- describe the native Settings integration, catalog filtering, and guarded install path

## Verification

- catalog API currently reports 4,153 tracked plugin entries across 3,498 repositories
- `git diff --check` passes
- the public Preview 5 release provides a fixed install artifact and SHA-256 checksum

Project: https://github.com/sandbaseai/dsh-plugin-store
Release: https://github.com/sandbaseai/dsh-plugin-store/releases/tag/v0.1.0-preview.5